### PR TITLE
Add group rule endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gems-
+          ${{ runner.os }}-${{ matrix.ruby }}-gems-
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+GIT
+  remote: https://github.com/vcr/vcr.git
+  revision: 480304be6d73803e6c4a0eb21a4ab4091da558d8
+  ref: 480304be6d73803e6c4a0eb21a4ab4091da558d8
+  branch: master
+  specs:
+    vcr (2.9.3)
+
+PATH
+  remote: .
+  specs:
+    oktakit (0.2.0)
+      sawyer (~> 0.8.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
+    byebug (11.1.3)
+    diff-lcs (1.4.1)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.1.1)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    public_suffix (4.0.5)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubocop (0.86.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.0.3, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
+    ruby-progressbar (1.10.1)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    unicode-display_width (1.7.0)
+    yard (0.9.25)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  byebug
+  oktakit!
+  rake
+  rspec (~> 3.2)
+  rubocop
+  vcr (~> 2.9)!
+  yard
+
+BUNDLED WITH
+   2.1.4

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -144,6 +144,21 @@ module Oktakit
       def list_assigned_applications(id, options = {})
         get("/groups/#{id}/apps", options)
       end
+
+      # Add Group Rule
+      #
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] The created Group Rule.
+      # @see http://developer.okta.com/docs/api/resources/groups.html#create-group-rule
+      # @example
+      #   Oktakit.add_group_rule
+      def add_group_rule(options = {})
+        post('/groups/rules', options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -190,6 +190,22 @@ module Oktakit
       def list_group_rules(options = {})
         get('/groups/rules', options)
       end
+
+      # Get Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] Fetched Group Rule
+      # @see http://developer.okta.com/docs/api/resources/groups.html#get-group-rule
+      # @example
+      #   Oktakit.get_group_rule('id')
+      def get_group_rule(id, options = {})
+        get("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -222,6 +222,22 @@ module Oktakit
       def activate_group_rule(id, options = {})
         post("/groups/rules/#{id}/lifecycle/activate", options)
       end
+
+      # Deactivate Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 204 No Content
+      # @see http://developer.okta.com/docs/api/resources/groups.html#deactivate-a-group-rule
+      # @example
+      #   Oktakit.deactivate_group_rule('id')
+      def deactivate_group_rule(id, options = {})
+        post("/groups/rules/#{id}/lifecycle/deactivate", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -159,6 +159,22 @@ module Oktakit
       def add_group_rule(options = {})
         post('/groups/rules', options)
       end
+
+      # Update Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] Updated Group Rule
+      # @see http://developer.okta.com/docs/api/resources/groups.html#update-group-rule
+      # @example
+      #   Oktakit.update_group('id')
+      def update_group_rule(id, options = {})
+        put("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -238,6 +238,22 @@ module Oktakit
       def deactivate_group_rule(id, options = {})
         post("/groups/rules/#{id}/lifecycle/deactivate", options)
       end
+
+      # Delete Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 202 Accepted
+      # @see http://developer.okta.com/docs/api/resources/groups.html#delete-a-group-rule
+      # @example
+      #   Oktakit.delete_group_rule('id')
+      def delete_group_rule(id, options = {})
+        delete("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -206,6 +206,22 @@ module Oktakit
       def get_group_rule(id, options = {})
         get("/groups/rules/#{id}", options)
       end
+
+      # Activate Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 204 No Content
+      # @see http://developer.okta.com/docs/api/resources/groups.html#activate-a-group-rule
+      # @example
+      #   Oktakit.activate_group_rule('id')
+      def activate_group_rule(id, options = {})
+        post("/groups/rules/#{id}/lifecycle/activate", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -175,6 +175,21 @@ module Oktakit
       def update_group_rule(id, options = {})
         put("/groups/rules/#{id}", options)
       end
+
+      # List Group Rules
+      #
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Array<Sawyer::Resource>] Array of Groups Rules
+      # @see http://developer.okta.com/docs/api/resources/groups.html#list-groups-rules
+      # @example
+      #   Oktakit.list_group_rules
+      def list_group_rules(options = {})
+        get('/groups/rules', options)
+      end
     end
   end
 end

--- a/spec/cassettes/activate_group_rule.yml
+++ b/spec/cassettes/activate_group_rule.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7/lifecycle/activate
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:14:36 GMT
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5J7GmsouxLEYfTWLAN5QAAFUI
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703336'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-frame-options:
+      - SAMEORIGIN
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=3ECAC11AAB32FBC011CDC45CC3C56CD0;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:14:32 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/add_group_rule.yml
+++ b/spec/cassettes/add_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules
+    body:
+      encoding: UTF-8
+      string: '{"name":"New Group Rule","type":"group_rule","conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}}}'
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 21 Oct 2019 23:43:20 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5CmNXJtAtvPoJxfwPXAgAADB8
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571701460'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=11811A0C3056C53B49C2D9C7570B9A49;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"New
+        Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:43:20.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 23:43:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/deactivate_group_rule.yml
+++ b/spec/cassettes/deactivate_group_rule.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7/lifecycle/deactivate
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:20:05 GMT
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5LNWUwbv163EGaFsEKGwAAD6I
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703665'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-frame-options:
+      - SAMEORIGIN
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=60C7C5774D58F58504017C60C978C663;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:20:01 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/delete_group_rule.yml
+++ b/spec/cassettes/delete_group_rule.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 202
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:23:20 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5L@DPyhtXiO0aIv6azHAAAClU
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703860'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=68EB5A5CE1BD7B598BA90CACA2D330BE;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:23:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/get_group_rule.yml
+++ b/spec/cassettes/get_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:10:40 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5JAA8k6jCS0MKkufPZ8AAAE6c
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703100'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=1CF3938F271486BDFE1C0418235993D2;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:10:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/list_group_rules.yml
+++ b/spec/cassettes/list_group_rules.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/groups/rules
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:01:50 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5G7lTOOSfcIa2PfBdtTgAAEj8
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571702570'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=C699FF50BF0527D17510A0A000B0BEB1;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '[{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}]'
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:01:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/update_group_rule.yml
+++ b/spec/cassettes/update_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: UTF-8
+      string: '{"name":"A New Group Rule","type":"group_rule","conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}}}'
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 21 Oct 2019 23:57:49 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5F-QU-bmF1Sa4VfDegxwAADxw
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '498'
+      x-rate-limit-reset:
+      - '1571702284'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=A9B08B7DE7E65065737F3367F148EE76;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 23:57:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -178,4 +178,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#deactivate_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'deactivates a group rule' do
+      VCR.use_cassette 'deactivate_group_rule' do
+        _, status = client.deactivate_group_rule(group_rule_id)
+        expect(status).to eq(204)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Oktakit::Client::Groups do
   GROUPS_GROUP_ID = '00g6o0uh8xcL5WbyZ0h7'
-  GROUPS_USER_ID = '00u6nm9ytbmwHeunx0h7'
+  GROUPS_USER_ID  = '00u6nm9ytbmwHeunx0h7'
 
   describe '#add_group' do
     it 'returns the created group.' do
       VCR.use_cassette 'add_group' do
         resp, = client.add_group(
           profile: {
-            name: "New Group Users",
+            name:        "New Group Users",
             description: "New Group Users"
           }
         )
@@ -41,7 +41,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'update_group' do
         resp, = client.update_group(GROUPS_GROUP_ID,
                                     profile: {
-                                      name: "New Name for the Group",
+                                      name:        "New Name for the Group",
                                       description: "New Name for the Group"
                                     })
         expect(resp.profile.name).to be == "New Name for the Group"
@@ -153,6 +153,17 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'list_group_rules' do
         resp, = client.list_group_rules
         expect(resp).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#get_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'returns a group rule' do
+      VCR.use_cassette 'get_group_rule' do
+        resp, = client.get_group_rule(group_rule_id)
+        expect(resp.id).not_to be_nil
       end
     end
   end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -147,4 +147,13 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#list_group_rules' do
+    it 'returns an array of group rules' do
+      VCR.use_cassette 'list_group_rules' do
+        resp, = client.list_group_rules
+        expect(resp).to be_a(Array)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -93,4 +93,30 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#add_group_rule' do
+    let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
+    let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
+
+    it 'returns the create group rule' do
+      VCR.use_cassette 'add_group_rule' do
+        resp, = client.add_group_rule(
+          name:       'New Group Rule',
+          type:       'group_rule',
+          conditions: {
+            expression: {
+              type:  'urn:okta:expression:1.0',
+              value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
+            }
+          },
+          actions:    {
+            assignUserToGroups: {
+              groupIds: group_ids_to_assign
+            }
+          })
+
+        expect(resp.id).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -42,7 +42,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'update_group' do
         resp, = client.update_group(GROUPS_GROUP_ID,
                                     profile: {
-                                      name:        "New Name for the Group",
+                                      name: "New Name for the Group",
                                       description: "New Name for the Group"
                                     })
         expect(resp.profile.name).to be == "New Name for the Group"
@@ -102,19 +102,20 @@ describe Oktakit::Client::Groups do
     it 'returns the create group rule' do
       VCR.use_cassette 'add_group_rule' do
         resp, = client.add_group_rule(
-          name:       'New Group Rule',
-          type:       'group_rule',
+          name: 'New Group Rule',
+          type: 'group_rule',
           conditions: {
             expression: {
-              type:  'urn:okta:expression:1.0',
+              type: 'urn:okta:expression:1.0',
               value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
             }
           },
-          actions:    {
+          actions: {
             assignUserToGroups: {
               groupIds: group_ids_to_assign
             }
-          })
+          }
+        )
 
         expect(resp.id).not_to be_nil
       end
@@ -128,15 +129,15 @@ describe Oktakit::Client::Groups do
     it 'returns the updated group rule' do
       VCR.use_cassette 'update_group_rule' do
         resp, = client.update_group_rule(group_rule_id,
-                                         name:       'A New Group Rule',
-                                         type:       'group_rule',
+                                         name: 'A New Group Rule',
+                                         type: 'group_rule',
                                          conditions: {
                                            expression: {
-                                             type:  'urn:okta:expression:1.0',
+                                             type: 'urn:okta:expression:1.0',
                                              value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
                                            }
                                          },
-                                         actions:    {
+                                         actions: {
                                            assignUserToGroups: {
                                              groupIds: group_ids_to_assign
                                            }

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Oktakit::Client::Groups do
   GROUPS_GROUP_ID = '00g6o0uh8xcL5WbyZ0h7'
   GROUPS_USER_ID  = '00u6nm9ytbmwHeunx0h7'
+  let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
 
   describe '#add_group' do
     it 'returns the created group.' do
@@ -121,8 +122,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#update_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
     let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
 
@@ -158,8 +157,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#get_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'returns a group rule' do
       VCR.use_cassette 'get_group_rule' do
         resp, = client.get_group_rule(group_rule_id)
@@ -169,8 +166,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#activate_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'activates a group rule' do
       VCR.use_cassette 'activate_group_rule' do
         _, status = client.activate_group_rule(group_rule_id)
@@ -180,8 +175,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#deactivate_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'deactivates a group rule' do
       VCR.use_cassette 'deactivate_group_rule' do
         _, status = client.deactivate_group_rule(group_rule_id)
@@ -191,8 +184,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#delete_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'deletes the group rule' do
       VCR.use_cassette 'delete_group_rule' do
         _, status = client.delete_group_rule(group_rule_id)

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -167,4 +167,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#activate_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'activates a group rule' do
+      VCR.use_cassette 'activate_group_rule' do
+        _, status = client.activate_group_rule(group_rule_id)
+        expect(status).to eq(204)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -189,4 +189,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#delete_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'deletes the group rule' do
+      VCR.use_cassette 'delete_group_rule' do
+        _, status = client.delete_group_rule(group_rule_id)
+        expect(status).to eq(202)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -119,4 +119,32 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#update_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
+    let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
+
+    it 'returns the updated group rule' do
+      VCR.use_cassette 'update_group_rule' do
+        resp, = client.update_group_rule(group_rule_id,
+                                         name:       'A New Group Rule',
+                                         type:       'group_rule',
+                                         conditions: {
+                                           expression: {
+                                             type:  'urn:okta:expression:1.0',
+                                             value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
+                                           }
+                                         },
+                                         actions:    {
+                                           assignUserToGroups: {
+                                             groupIds: group_ids_to_assign
+                                           }
+                                         })
+
+        expect(resp.id).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -10,7 +10,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'add_group' do
         resp, = client.add_group(
           profile: {
-            name:        "New Group Users",
+            name: "New Group Users",
             description: "New Group Users"
           }
         )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require 'oktakit'
 module TestClient
   extend RSpec::SharedContext
   let(:client) do
-    Oktakit::Client.new(token:        test_okta_token,
+    Oktakit::Client.new(token: test_okta_token,
                         organization: test_okta_organization,
                         api_endpoint: test_okta_api_endpoint)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,11 @@ require 'oktakit'
 
 module TestClient
   extend RSpec::SharedContext
-  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test') }
+  let(:client) do
+    Oktakit::Client.new(token:        test_okta_token,
+                        organization: test_okta_organization,
+                        api_endpoint: test_okta_api_endpoint)
+  end
 end
 
 RSpec.configure do |config|
@@ -40,4 +44,12 @@ end
 
 def test_okta_token
   ENV.fetch('OKTA_TEST_TOKEN', 'x' * 40)
+end
+
+def test_okta_organization
+  ENV.fetch('OKTA_TEST_ORGANIZATION', 'okta-test')
+end
+
+def test_okta_api_endpoint
+  ENV['OKTA_TEST_API_ENDPOINT']
 end


### PR DESCRIPTION
## Problem

The Okta API supports [group rules](https://developer.okta.com/docs/reference/api/groups/#group-rule-operations), but the client is missing them.
 
## Proposal

- Add the group rule endpoints

###  Other fixes

The spec helper didn't have a way to mock which server to communicate to. I don't have access to `okta-test.okta.com`, so I used environment variables to talk to my instance of Okta.